### PR TITLE
fix styles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { IconButton, Theme, StyledEngineProvider, ThemeProvider, Typography } fr
 import { ArrowBack } from '@mui/icons-material';
 import { GarageItem } from './types/garage';
 import { MockGarage } from './utils/constants';
+import { buildRespObj } from './utils/misc';
 import { VehicleList } from './components/VehicleList';
 import fetchNui from './utils/fetchNui';
 import { ServerPromiseResp } from './types/common';
@@ -42,8 +43,12 @@ const App = (props: AppProps) => {
   const isDarkMode = props.theme.palette.mode === 'dark';
 
   useEffect(() => {
-    fetchNui<ServerPromiseResp<GarageItem[]>>('npwd:qb-garage:getVehicles').then((resp) => {
-      setVehicles(resp.data);
+    fetchNui<ServerPromiseResp<GarageItem[]>>(
+      'npwd:qb-garage:getVehicles',
+      null,
+      buildRespObj(MockGarage)
+      ).then((resp) => {
+        setVehicles(resp.data);
     });
   }, []);
 

--- a/src/components/VehicleDetails.tsx
+++ b/src/components/VehicleDetails.tsx
@@ -62,7 +62,13 @@ const VehicleDetails = ({ veh }: { veh: GarageItem }) => {
         </ListItem>
       </List>
 
-      <Button color="primary" variant="contained" disabled={veh.state !== 'out'} onClick={() => handleTrackVehicle(veh.plate)}>
+      <Button
+        color="primary"
+        variant="contained"
+        disabled={veh.state !== 'out'}
+        onClick={() => handleTrackVehicle(veh.plate)}
+        style={{ color: '#FFFFFF', backgroundColor: '#212121' }}
+      >
         Track
       </Button>
     </>


### PR DESCRIPTION
Returns the mock data for `getVehicles` so when you run in the browser with `yarn dev` it will load the data
Fixes some styling issues

_Note: We found that these styling issues are caused by the Tailwind styles imported in the phone/src/main.css. It is styling button tag directly and as a result overrides the MUI styles in many places. This solution is more of a short term / bandaid fix until a longer term solution is figured out with the use of Tailwind and MUI styles._

BEFORE
![image](https://github.com/npwd-community/npwd_qb_garage/assets/18689469/b51133ed-c1f8-4f01-972b-b92d751ada82)
![image](https://github.com/npwd-community/npwd_qb_garage/assets/18689469/12876f80-f58e-4b37-872c-b10adc66031e)

AFTER
![image](https://github.com/npwd-community/npwd_qb_garage/assets/18689469/33216a09-c592-42e6-97a7-e0c2dc00b93f)
![image](https://github.com/npwd-community/npwd_qb_garage/assets/18689469/fa880e56-3b7c-4885-9d3a-57972ef2f407)
